### PR TITLE
Fixed error "fpos_t" for BCN3D on Arduino 1.8.0+

### DIFF
--- a/BCN3D/SdBaseFile.cpp
+++ b/BCN3D/SdBaseFile.cpp
@@ -294,7 +294,7 @@ bool SdBaseFile::getFilename(char* name) {
   return true;
 }
 //------------------------------------------------------------------------------
-void SdBaseFile::getpos(fpos_t* pos) {
+void SdBaseFile::getpos(fpos_t1* pos) {
   pos->position = curPosition_;
   pos->cluster = curCluster_;
 }
@@ -925,7 +925,7 @@ bool SdBaseFile::openRoot(SdVolume* vol) {
  * \return The byte if no error and not at eof else -1;
  */
 int SdBaseFile::peek() {
-  fpos_t pos;
+  fpos_t1 pos;
   getpos(&pos);
   int c = read();
   if (c >= 0) setpos(&pos);
@@ -1492,7 +1492,7 @@ bool SdBaseFile::seekSet(uint32_t pos) {
   return false;
 }
 //------------------------------------------------------------------------------
-void SdBaseFile::setpos(fpos_t* pos) {
+void SdBaseFile::setpos(fpos_t1* pos) {
   curPosition_ = pos->position;
   curCluster_ = pos->cluster;
 }

--- a/BCN3D/SdBaseFile.h
+++ b/BCN3D/SdBaseFile.h
@@ -31,16 +31,16 @@
 #include "SdVolume.h"
 //------------------------------------------------------------------------------
 /**
- * \struct fpos_t
+ * \struct fpos_t1
  * \brief internal type for istream
  * do not use in user apps
  */
-struct fpos_t {
+struct fpos_t1 {
   /** stream position */
   uint32_t position;
   /** cluster for position */
   uint32_t cluster;
-  fpos_t() : position(0), cluster(0) {}
+  fpos_t1() : position(0), cluster(0) {}
 };
 
 // use the gnu style oflag in open()
@@ -196,11 +196,11 @@ class SdBaseFile {
   /** get position for streams
    * \param[out] pos struct to receive position
    */
-  void getpos(fpos_t* pos);
+  void getpos(fpos_t1* pos);
   /** set position for streams
    * \param[out] pos struct with value for new position
    */
-  void setpos(fpos_t* pos);
+  void setpos(fpos_t1* pos);
   //----------------------------------------------------------------------------
   bool close();
   bool contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock);


### PR DESCRIPTION
Teníamos un error con `struct fpos_t` al instalar la última versión de Arduino, este cambio lo soluciona.

El nombre no es el mejor, lo renombramos a `fpos_t1`, si alguien tiene un nombre más apropiado podemos cambiarlo.

Cambio hecho con @amatiasq.